### PR TITLE
自動更新機能の実装

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,8 +1,33 @@
 $(function(){
+
+  var reloadMessages = function() {
+    var last_message_id = $('.message:last').data("message-id");
+    $.ajax({
+      url: "api/messages",
+      type: "GET",
+      dataType: "json",
+      data: {id: last_message_id}
+    })
+    .done(function(messages) {
+      if (messages.length !== 0) {
+        var insertHTML = '';
+        $.each(messages, function(i, message) {
+          insertHTML += buildHTML(message)
+      });
+      $('.messages').append(insertHTML);
+      $('.messages').animate({ scrollTop: $('.messages')[0].scrollHeight});
+      }     
+    })
+    .fail(function() {
+      alert('error');
+    })
+  }
+
+
   function buildHTML(message) {
     if (message.content && message.image) {
       var html = 
-      `<div class="message">
+      `<div class="message" data-message-id=${message.id}>
         <div class="message__upper-info">
           <div class="message__upper-info__talker">
             ${message.user_name}
@@ -18,7 +43,7 @@ $(function(){
       </div>`
     } else if (message.content) {
       var html = 
-      `<div class="message">
+      `<div class="message" data-message-id=${message.id}>
           <div class="message__upper-info">
             <div class="message__upper-info__talker">
               ${message.user_name}
@@ -33,7 +58,7 @@ $(function(){
         </div>`
     } else if (message.image) {
       var html = 
-      `<div class="message">
+      `<div class="message" data-message-id=${message.id}>
           <div class="message__upper-info">
             <div class="message__upper-info__talker">
               ${message.user_name}
@@ -73,4 +98,7 @@ $(function(){
       alert('メッセージ送信に失敗しました');
     })
   });
+  if (document.location.href.match(/\/groups\/\d+\/messages/)) {
+    setInterval(reloadMessages, 7000);
+  }
 });

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,7 @@
+class Api::MessagesController < ApplicationController
+  def index
+    group = Group.find(params[:group_id])
+    last_message_id = params[:id].to_i
+    @messages = group.messages.includes(:user).where("id > ?", last_message_id)
+  end
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,7 +1,7 @@
 json.array! @messages do |message|
   json.content      message.body
   json.image        message.image.url
-  json.created_at   message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+  json.created_at   message.created_at.to_s(:datetime)
   json.user_name    message.user.name
   json.id           message.id
 end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.content      message.body
+  json.image        message.image.url
+  json.created_at   message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+  json.user_name    message.user.name
+  json.id           message.id
+end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.message
+.message{data: {message: {id: message.id}}}
   .message__upper-info
     .message__upper-info__talker
       = message.user.name

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -3,7 +3,7 @@
     .message__upper-info__talker
       = message.user.name
     .message__upper-info__date
-      = message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+      = message.created_at.to_s(:datetime)
   .message__text
     - if message.body.present?
       = message.body

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -2,3 +2,4 @@ json.user_name        @message.user.name
 json.created_at       @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
 json.content          @message.body
 json.image            @message.image.url
+json.id               @message.id

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,5 +1,5 @@
 json.user_name        @message.user.name
-json.created_at       @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+json.created_at       @message.created_at.strftime.to_s(:datetime)
 json.content          @message.body
 json.image            @message.image.url
 json.id               @message.id

--- a/config/initializers/time.formats.rb
+++ b/config/initializers/time.formats.rb
@@ -1,0 +1,1 @@
+Time::DATE_FORMATS[:datetime] = "%Y年%m月%d日 %H時%M分"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,10 @@ Rails.application.routes.draw do
   resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:index, :new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
+
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }
+    end
   end
 
 end


### PR DESCRIPTION
# What
最新の投稿メッセージを取得し、7秒ごとに自動更新されるように実装した。

# Why
これまでは自分が投稿したメッセージは非同期に投稿することができていたが、
別のブラウザには、このメッセージが反映されておらず、リロードしてページを読み込む必要がある。
いちいちリロードしなくても相手からのメッセージが表示されるようになり、快適にチャットができるようにするため、自動更新機能を実装する必要があった。

### 動作確認画面
[![Image from Gyazo](https://i.gyazo.com/ad5a1fcd59362668bcc4d1074a81d538.gif)](https://gyazo.com/ad5a1fcd59362668bcc4d1074a81d538)